### PR TITLE
Update 03-ros-primer.ipynb -- removed the roslaunch command

### DIFF
--- a/1-foundations/0-primers/03-ros-primer.ipynb
+++ b/1-foundations/0-primers/03-ros-primer.ipynb
@@ -150,22 +150,6 @@
             "metadata": {},
             "source": [
                 "\n",
-                "#### roslaunch\n",
-                "\n",
-                "The roslaunch command allows you to run multiple ROS nodes with a single command. It also allows you to set parameters on the nodes, and to specify remapping rules for topics. For example, to launch the turtlesim_node from the turtlesim package, you can use the following command:\n",
-                "\n",
-                "```bash\n",
-                "# stop the turtlesim_node if it is running\n",
-                "# in a new terminal run turtlesim_node using roslaunch\n",
-                "roslaunch turtlesim turtlesim_node.launch\n",
-                "```"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "\n",
                 "### rosnode\n",
                 "\n",
                 "The rosnode command allows you to get information about running ROS nodes. For example, to get a list of all running nodes, you can use the following command:\n",


### PR DESCRIPTION
Hey Michael, 
Just removed the ros launch part from the ros primers as  turtlesim package does not contain a launch file
